### PR TITLE
Patch 1

### DIFF
--- a/src/jquery-ui.unobtrusive.js
+++ b/src/jquery-ui.unobtrusive.js
@@ -45,8 +45,12 @@
                     }
                 });
 
-                // Call jQuery UI fn if it exists
-                ($el[fn] || $.noop).call($el, options);
+                // get UI fn if it exists
+                var uiFn = ($el[fn] || $.noop);
+                // call destroy to remove the ui widget
+                uiFn.call($el, 'destroy');
+                // call fn with options
+                uiFn.call($el, options);
             });
         }
     }

--- a/src/jquery-ui.unobtrusive.js
+++ b/src/jquery-ui.unobtrusive.js
@@ -1,19 +1,31 @@
-﻿/*!
- * Unobtrusive jQuery UI 0.1
- * Copyright 2011, Damian Edwards http://damianedwards.com
- * Licensed under Ms-PL
- * http://www.opensource.org/licenses/MS-PL
- */
+/*!
+* Unobtrusive jQuery UI 0.1
+* Copyright 2011, Damian Edwards http://damianedwards.com
+* Licensed under Ms-PL
+* http://www.opensource.org/licenses/MS-PL
+*/
+
+/*!
+* Modified by Andrew Cohen, 11/30/2011
+* TempWorks Software, Inc.
+*/
+
 (function ($) {
-	"use strict";
-	
-    $(function () {
-        var prefix = "data-ui-";
-        
-        // Wire-up jQuery UI unobtrusively
-        $("*[" + prefix + "fn]").each(function () {
-            var el = this,
-                $el = $(el);
+    "use strict";
+
+    var $jQui = $.ui,
+        prefix = "data-ui-";
+
+    $jQui.unobtrusive = {
+        parse: function (element) {
+            // Wire-up jQuery UI unobtrusively
+            $("*[" + prefix + "fn]", element).each(function () {
+                $jQui.unobtrusive.parseElement(this);
+            });
+        },
+        parseElement: function (el) {
+            var $el = $(el),
+                el = $el[0];
 
             // Loop through functions in data-ui-fn attribute
             $.each($el.attr(prefix + "fn").split(" "), function () {
@@ -25,16 +37,22 @@
                 $.each(el.attributes, function () {
                     var attr = this;
                     if (!attr.specified) return true;
-                    
+
                     if (attr.name.indexOf(optionPrefix) === 0) {
-                        options[attr.name.substr(optionPrefix.length)] = attr.value;
+                        // camelCase the name
+                        var attrName = $.camelCase(attr.name.substr(optionPrefix.length));
+                        options[attrName] = attr.value;
                     }
                 });
 
                 // Call jQuery UI fn if it exists
                 ($el[fn] || $.noop).call($el, options);
             });
-        });
+        }
+    }
+
+    $(function () {
+        $jQui.unobtrusive.parse(document);
     });
 
-}(window.jQuery));
+} (window.jQuery));

--- a/src/jquery-ui.unobtrusive.js
+++ b/src/jquery-ui.unobtrusive.js
@@ -16,6 +16,21 @@
     var $jQui = $.ui,
         prefix = "data-ui-";
 
+    function getFunction(fn) {
+        /// <param name="fn" type="String">String of function to parse</param>
+        /// <returns type="Function" />
+        /// <summary>Takes a string and converts it to an anonymous function</summary>
+        var fnMatches = fn.match(/function\((.*?)\).*?\{(.*)\}$/);
+        if (fnMatches) {
+            var argsMatches = fnMatches[1].split(','),
+                argsString = '';
+            for (var i = 0; i < argsMatches.length; i++) {
+                argsMatches[i] = '"' + $.trim(argsMatches[i]) + '"';
+            }
+            return eval('new Function(' + argsMatches.join(',') + ', "' + fnMatches[2] + '")');
+        }
+    };
+
     $jQui.unobtrusive = {
         parse: function (element) {
             // Wire-up jQuery UI unobtrusively
@@ -40,7 +55,11 @@
 
                     if (attr.name.indexOf(optionPrefix) === 0) {
                         // camelCase the name
-                        var attrName = $.camelCase(attr.name.substr(optionPrefix.length));
+                        if (attr.value.substr(0, 8) === 'function') { // test for anonymous function
+                            options[attrName] = getFunction(attr.value);
+                        } else {
+                            options[attrName] = attr.value;
+                        }
                         options[attrName] = attr.value;
                     }
                 });


### PR DESCRIPTION
Split apart original code into two functions inside the jQuery UI namespace of $.ui.unobtrusive; parse and parseElement.  The original code ran the entire block inside the document ready event.  Putting it into functions allows you to be able to call them again after page load.  This is useful for AJAX loaded content.

I also added support for camelCased jQuery widget options inside the data-attributes.

Made sure that each DOM element that is operated on, first had a destroy widget call as per the jQuery UI suggested guidelines.
