### PR TITLE
Support for options that expect [objects]

### DIFF
--- a/src/jquery-ui.unobtrusive.js
+++ b/src/jquery-ui.unobtrusive.js
@@ -36,6 +36,19 @@
         }
     }
 
+    function getOptionsObject(options, attrName, value) {
+        var options = options || {};
+        var propName = attrName.substring(attrName.indexOf('_') + 1);
+        if (propName.indexOf('_') != -1) {
+            var option = propName.substring(0, propName.indexOf('_'));
+            options[option] = getOptionsObject(options[option], propName, value);
+        }
+        else {
+            options[propName] = value;
+        }
+        return options;
+    }
+
     $jQui.unobtrusive = {
 
         parse: function (context) {
@@ -77,6 +90,9 @@
                         // test for anonymous function
                         if (attr.value.substr(0, 8) === 'function') {
                             options[attrName] = getFunction(attr.value);
+                        } else if (attrName.indexOf('_') != -1) {
+                            var option = attrName.substring(0, attrName.indexOf('_'));
+                            options[option] = getOptionsObject(options[option], attrName, attr.value);
                         } else {
                             options[attrName] = attr.value;
                         }


### PR DESCRIPTION
Hey, could you take a look at this change I made to support options that expect objects.

I use this library a lot, it's great, but I also like to use buttons with icons and text.

These options are handled with data-ui-button-icons_primary="ui-icon-plus"
_ in attribute name indicates new object.
